### PR TITLE
Added status and 1:1 relation

### DIFF
--- a/src/server/db/migrations/5-status.main.js
+++ b/src/server/db/migrations/5-status.main.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const DataTypes = require('sequelize');
+const Promise = require('bluebird');
+
+module.exports.up = function(db, config)
+{
+    const queryInterface = db.getQueryInterface();
+
+
+    const one = db.queryInterface.addColumn(
+        'PdfChannelConfig',
+        'status',
+        {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        }
+    );
+
+    const two = db.queryInterface.addColumn(
+        'PaperChannelConfig',
+        'status',
+        {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        }
+    );
+
+    const three = db.queryInterface.addColumn(
+        'EInvoiceChannelConfig',
+        'status',
+        {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        }
+    );
+
+    const four = db.queryInterface.addColumn(
+        'SupplierPortalConfig',
+        'status',
+        {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        }
+    );
+
+
+    // const nine = queryInterface.changeColumn('PdfChannelConfig', 'supplierId', {
+    //   type : DataTypes.STRING(30),
+    //   allowNull : false,
+    //   primaryKey : true,
+    //   references : {
+    //       model : 'InChannelConfig',
+    //       key : 'supplierId'
+    //   }
+    // });
+    const promm = Promise.all([one, two, three, four]).then(() => {
+      const five  = queryInterface.sequelize.query('UPDATE `PdfChannelConfig` JOIN `InChannelConfig` on `PdfChannelConfig`.`supplierId` = `InChannelConfig`.`supplierId` SET `PdfChannelConfig`.`status` = `InChannelConfig`.`status`')
+      const six   = queryInterface.sequelize.query('UPDATE `einvoice`.`PaperChannelConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`PaperChannelConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`PaperChannelConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
+      const seven = queryInterface.sequelize.query('UPDATE `einvoice`.`EInvoiceChannelConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`EInvoiceChannelConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`EInvoiceChannelConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
+      const eight = queryInterface.sequelize.query('UPDATE `einvoice`.`SupplierPortalConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`SupplierPortalConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`SupplierPortalConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
+      return Promise.all([five,six,seven,eight]);
+    }
+    );
+
+
+
+
+    // return Promise.all([one, two, three, four]);
+    return promm;
+}
+
+module.exports.down = function(db, config)
+{
+    const one = db.queryInterface.dropColumn('PdfChannelConfig', 'status');
+    const two = db.queryInterface.dropColumn('PaperChannelConfig', 'status');
+    const three = db.queryInterface.dropColumn('EInvoiceChannelConfig', 'status');
+    const four = db.queryInterface.dropColumn('SupplierPortalConfig', 'status');
+
+    return Promise.all([one, two, three, four]);
+}

--- a/src/server/db/migrations/5-status.main.js
+++ b/src/server/db/migrations/5-status.main.js
@@ -58,14 +58,43 @@ module.exports.up = function(db, config)
     //       key : 'supplierId'
     //   }
     // });
+    //
+
+
+
+
+
+
+
     const promm = Promise.all([one, two, three, four]).then(() => {
-      const five  = queryInterface.sequelize.query('UPDATE `PdfChannelConfig` JOIN `InChannelConfig` on `PdfChannelConfig`.`supplierId` = `InChannelConfig`.`supplierId` SET `PdfChannelConfig`.`status` = `InChannelConfig`.`status`')
-      const six   = queryInterface.sequelize.query('UPDATE `einvoice`.`PaperChannelConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`PaperChannelConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`PaperChannelConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
-      const seven = queryInterface.sequelize.query('UPDATE `einvoice`.`EInvoiceChannelConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`EInvoiceChannelConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`EInvoiceChannelConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
-      const eight = queryInterface.sequelize.query('UPDATE `einvoice`.`SupplierPortalConfig` JOIN `einvoice`.`InChannelConfig` ON `einvoice`.`SupplierPortalConfig`.`supplierId` = `einvoice`.`InChannelConfig`.`supplierId` SET `einvoice`.`SupplierPortalConfig`.`status` = `einvoice`.`InChannelConfig`.`status`')
-      return Promise.all([five,six,seven,eight]);
+      const all = db.models.InChannelConfig.findAll().map(config => {
+        switch (config.inputType) {
+          case 'pdf':
+            return db.models.PdfChannelConfig.update({ status: config.status}, {
+              where: { supplierId: config.supplierId}
+            })
+            break;
+          case 'einvoice':
+          return db.models.EInvoiceChannelConfig.update({ status: config.status}, {
+            where: { supplierId: config.supplierId}
+          })
+          break;
+          case 'paper':
+          return db.models.PaperChannelConfig.update({ status: config.status}, {
+            where: { supplierId: config.supplierId}
+          })
+          break;
+          case 'supplierPortal':
+          return db.models.SupplierPortalConfig.update({ status: config.status}, {
+            where: { supplierId: config.supplierId}
+          })
+          break;
+        }
+      });
+  
+      return Promise.all(all);
     }
-    );
+  );
 
 
 

--- a/src/server/db/models/inChannelConfig.js
+++ b/src/server/db/models/inChannelConfig.js
@@ -58,5 +58,318 @@ module.exports.init = function(db, config)
         freezeTableName : true
     });
 
+    /**
+     * Data model representing an invoice send configuration.
+     * @class PdfChannelConfig
+     */
+    var PdfChannelConfig = db.define('PdfChannelConfig',
+    /** @lends PdfChannelConfig */
+    {
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false,
+            primaryKey : true
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false,
+            defaultValue : ''
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true
+        },
+        rejectionEmail: {
+            type:DataTypes.STRING(30),
+            allowNull:true
+        },
+        status: {
+            type:DataTypes.STRING(100),
+            allowNull:false,
+            defaultValue:'new'
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true,
+        // classMethods: {
+        //   associate: function(db) {
+        //     PdfChannelConfig.belongsTo(db.InChannelConfig, {targetKey: 'supplierId'});
+        //   }
+        // }
+    });
+
+    /**
+     * Data model representing an invoice send configuration
+     * @class PaperChannelConfig
+     */
+    var PaperChannelConfig = db.define('PaperChannelConfig',
+    {
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false,
+            primaryKey : true
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false,
+            defaultValue : ''
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true
+        },
+        status: {
+            type:DataTypes.STRING(100),
+            allowNull:false,
+            defaultValue:'new'
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true
+    });
+
+    /**
+     * Data model representing an invoice send configuration.
+     * @class EInvoiceChannelConfig
+     */
+    var EInvoiceChannelConfig = db.define('EInvoiceChannelConfig',
+    /** @lends EInvoiceChannelConfig */
+    {
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false,
+            primaryKey : true
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false,
+            defaultValue : ''
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true
+        },
+        intention : {
+            type:DataTypes.BOOLEAN,
+            allowNull:true
+        },
+        status: {
+            type:DataTypes.STRING(100),
+            allowNull:false,
+            defaultValue:'new'
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true
+    });
+
+    /**
+     * Data model representing an invoice send configuration.
+     * @class SupplierPortalConfig
+     */
+    var SupplierPortalConfig = db.define('SupplierPortalConfig',
+    /** @lends SupplierPortalConfig */
+    {
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false,
+            primaryKey : true
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false,
+            defaultValue : ''
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true
+        },
+        status: {
+            type:DataTypes.STRING(100),
+            allowNull:false,
+            defaultValue:'new'
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true
+    });
+
+    /**
+     * Data model representing an inChannelContract between a supplier and a customer.
+     */
+    var InChannelContract = db.define('InChannelContract',
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true
+        },
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false
+        },
+        customerId : {
+            type : DataTypes.STRING(30),
+            allowNull : false
+        },
+        customerSupplierId: {
+            type : DataTypes.STRING(30),
+            allowNull : true
+        },
+        billingModelId : {
+            type : DataTypes.STRING(30),
+            allowNull : true
+        },
+        inputType : {
+            type : DataTypes.STRING(30),
+            allowNull : true
+        },
+        // new, approved, inWork, activated
+        status : {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        },
+        voucherId: {
+            type: DataTypes.INTEGER,
+            allowNull : true
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : true
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true,
+            defaultValue : DataTypes.NOW
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true
+    });
+
+    var voucher = db.define('Voucher',
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true
+        },
+        customerId : {
+            type : DataTypes.STRING(30),
+            allowNull : false
+        },
+        supplierId : {
+            type : DataTypes.STRING(30),
+            allowNull : false
+        },
+        billingModelId : {
+            type : DataTypes.STRING(30),
+            allowNull : true
+        },
+        customerSupplierId: {
+            type : DataTypes.STRING(30),
+            allowNull : true
+        },
+        // new, approved
+        status : {
+            type : DataTypes.STRING(100),
+            allowNull : false,
+            defaultValue : 'new'
+        },
+        createdBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false
+        },
+        changedBy : {
+            type : DataTypes.STRING(60),
+            allowNull : false,
+            defaultValue : ''
+        },
+        createdOn : {
+            type : DataTypes.DATE(),
+            allowNull : false,
+            defaultValue : DataTypes.NOW
+        },
+        changedOn : {
+            type : DataTypes.DATE(),
+            allowNull : true
+        }
+    }, {
+        updatedAt : 'changedOn',
+        createdAt : 'createdOn',
+        freezeTableName : true
+    });
+
+    var relations = Promise.all([InChannelConfig,
+      PdfChannelConfig,
+      PaperChannelConfig,
+      EInvoiceChannelConfig,
+      SupplierPortalConfig,
+      InChannelContract,
+      voucher]).then(() => {
+        var one = PdfChannelConfig.belongsTo(InChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var two = PaperChannelConfig.belongsTo(InChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var three = EInvoiceChannelConfig.belongsTo(InChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var four = SupplierPortalConfig.belongsTo(InChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+
+        var five = InChannelConfig.hasOne(PdfChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var six = InChannelConfig.hasOne(PaperChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var seven = InChannelConfig.hasOne(EInvoiceChannelConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+        var eight = InChannelConfig.hasOne(SupplierPortalConfig, {targetKey: "supplierId", foreignKey: "supplierId"});
+      });
+
+
+
     return Promise.resolve();
 }

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -15,11 +15,11 @@ module.exports.init = function(db, config)
 {
     return Promise.all([
         require('./inChannelConfig.js').init(db, config),
-        require('./pdfChannelConfig.js').init(db, config),
-        require('./paperChannelConfig.js').init(db, config),
-        require('./eInvoiceChannelConfig.js').init(db, config),
-        require('./supplierPortalConfig.js').init(db, config),
-        require('./voucher.js').init(db, config),
-        require('./inChannelContract.js').init(db, config)
+        // require('./pdfChannelConfig.js').init(db, config),
+        // require('./paperChannelConfig.js').init(db, config),
+        // require('./eInvoiceChannelConfig.js').init(db, config),
+        // require('./supplierPortalConfig.js').init(db, config),
+        // require('./voucher.js').init(db, config),
+        // require('./inChannelContract.js').init(db, config)
     ]);
 }


### PR DESCRIPTION
#57 
Edited schema:

- Added column `status` to `PdfChannelConfig`, `PaperChannelConfig`, `EInvoiceChannelConfig` and `SupplierPortalConfig` tables. Default - 'new'. Migration pulls status from `InChannelConfig`.
- Added 1:1 relation between the `InChannelConfig` to each above: hasOne + belongsTo.

**Attention**
The file `index.js` is now pulling only one file `inChannelConfig.js` , that now consists all Models. Unused files still remain there.