### PR TITLE
Added `Supplier Portal` support

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -7,6 +7,7 @@ import ServiceConfigFlowStart      from './components/ServiceConfigFlowStart.js'
 import ServiceConfigFlowFramePdf   from './components/ServiceConfigFlowPdf/ServiceConfigFlow.js'
 import ServiceConfigFlowFramePaper from './components/ServiceConfigFlowPaper/ServiceConfigFlow.js'
 import ServiceConfigFlowEInvoice   from './components/ServiceConfigFlowEinvoice/ServiceConfigFlow.js'
+import ServiceConfigFlowPortal   from './components/ServiceConfigFlowPortal/ServiceConfigFlow.js'
 import Layout from './layout.js';
 
 
@@ -96,7 +97,7 @@ export default class App extends React.Component
             // Convention for now: Use boolen to enable or disable the different input types:
             voucher.eInvoiceEnabled = true; // !!! only for the supplier to confirm their intention
             voucher.pdfEnabled = true;
-            voucher.supplierPortalEnabled = false; // !!! no flow ui available up to now
+            voucher.supplierPortalEnabled = true;
             voucher.paperEnabled = false;
 
             return this.getCustomer(voucher.customerId)
@@ -193,6 +194,25 @@ export default class App extends React.Component
         this.history.push("/");
     }
 
+    updatePortalAndGotoStart = (intention = null) => {
+        if (intention != null) {
+            let config = this.state.inChannelConfig;
+            if (config) {
+                if (!config.SupplierPortalConfig) {
+                    config.SupplierPortalConfig = {};
+                }
+                config.SupplierPortalConfig.intention = intention;
+                this.setState({
+                    inChannelConfig: config
+                });
+            }
+            else {
+                this.loadInChannelConfig();
+            }
+        }
+        this.history.push("/");
+    }
+
     finalizeFlow = () => {
         window.location.href = "/bnp/dashboard";
     }
@@ -235,6 +255,7 @@ export default class App extends React.Component
 
                     <Route path="/einvoice" component={ () => (<ServiceConfigFlowEInvoice currentTab={1} gotoStart={this.updateEinvoiceAndGotoStart} finalizeFlow={this.finalizeFlow} voucher={this.state.voucher}  inChannelConfig={this.state.inChannelConfig} customerTermsAndConditions={this.state.customerTermsAndConditions} />) } />
 
+                    <Route path="/portal" component={ () => (<ServiceConfigFlowPortal currentTab={1} gotoStart={this.updatePortalAndGotoStart} finalizeFlow={this.finalizeFlow} voucher={this.state.voucher}  inChannelConfig={this.state.inChannelConfig} customerTermsAndConditions={this.state.customerTermsAndConditions} />) } />
                 </Route>
             </Router>
         );

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -170,7 +170,7 @@ export default class App extends React.Component
     ///////////////////////////////////////////
 
     navigate2Flow = (inputType) => {
-        ajax.get('/einvoice-send/api/config/inchannels/' + this.state.user.supplierId)
+        return ajax.get('/einvoice-send/api/config/inchannels/' + this.state.user.supplierId)
             .set('Content-Type', 'application/json')
         .then ((config) => {
             if (config) {

--- a/src/client/components/ServiceConfigFlowPortal/ServiceConfigFlow.js
+++ b/src/client/components/ServiceConfigFlowPortal/ServiceConfigFlow.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { Button, Nav, NavItem, Tab, Row } from 'react-bootstrap';
+import ajax from 'superagent-bluebird-promise';
+
+import ServiceConfigFlow1 from './ServiceConfigFlow1.js';
+
+
+import InChannelConfig from '../../api/InChannelConfig.js';
+import InChannelContract from '../../api/InChannelContract.js';
+
+
+// A workaround to prevent a browser warning about unknown properties 'active', 'activeKey' and 'activeHref'
+// in DIV element.
+const MyDiv = () =>
+{
+    return <div className="connecting-line"/>;
+};
+
+
+export default class ServiceConfigFlow extends React.Component
+{
+    static propTypes = {
+        currentTab : React.PropTypes.number,
+        lastValidTab : React.PropTypes.number,
+        inputType: React.PropTypes.string,
+        // inChannelConfig : React.PropTypes.object  // really needed?
+    };
+
+    static defaultProps = {
+        currentTab : 1,
+        lastValidTab : 1,
+        inputType: null
+    };
+
+    constructor(props)
+    {
+        super(props);
+
+        this.state = {
+            currentTab : this.props.currentTab,
+            lastValidTab : this.props.lastValidTab,
+            inputType: this.props.inputType
+        };
+    }
+
+
+    static contextTypes = {
+        i18n : React.PropTypes.object.isRequired,
+    };
+
+
+
+    render()
+    {
+        var visible = {
+            display: (1==1) ? 'block' : 'none'
+        }
+
+        return (
+            <div style={{ minHeight: '100vh' }}>
+                <section className="content" style={{ overflow: 'visible' }}>
+                    <div className="content-wrap">
+                        <div className="container">
+                            <section className="header">
+                                <h1>
+                                    {this.context.i18n.getMessage('ServiceConfigFlow.header')}
+                                    <div className="control-bar text-right pull-right">
+                                        <Button onClick={ () => this.props.gotoStart()}>
+                                            <i className="fa fa-angle-left"/>
+                                            &nbsp;&nbsp;{this.context.i18n.getMessage('ServiceConfigFlow.backToTypeSelection')}
+                                        </Button>
+                                    </div>
+                                </h1>
+                            </section>
+
+                            <div className="container">
+                                <div className="row">
+                                    <section>
+                                        <div className="wizard">
+                                            <div className="wizard-inner">
+                                                <Tab.Container activeKey={ this.state.currentTab } onSelect={ currentTab => this.setState({ currentTab }) } id="stepsContainer">
+                                                    <Row className="clearfix">
+                                                        <PortalNav
+                                                            currentTab={this.state.currentTab}
+                                                            customerTermsAndConditions={this.props.customerTermsAndConditions} />
+                                                        <PortalTabContent
+                                                            forward={this.props.gotoStart}
+                                                            back={this.props.gotoStart}
+                                                            voucher = {this.props.voucher}
+                                                            inChannelConfig={this.props.inChannelConfig}
+                                                        />
+                                                    </Row>
+                                                </Tab.Container>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        )
+    }
+}
+
+
+class PortalNav extends React.Component {
+    render() {
+            return (
+                <Nav bsStyle="tabs">
+                    <MyDiv/>
+                    {/* see http://getbootstrap.com/components/ */}
+                    <NavItem eventKey={1}>
+                        <span className="round-tab"><i className="glyphicon glyphicon-pencil"/></span>
+                    </NavItem>
+                </Nav>
+            );
+        }
+}
+
+
+class PortalTabContent extends React.Component {
+    render() {
+        if (this.props.customerTermsAndConditions) {
+            return (
+                <Tab.Content>
+                    <Tab.Pane eventKey={1}>
+                        <ServiceConfigFlow1
+                            gotoStart={this.props.forward}
+                            voucher = {this.props.voucher}/>
+                    </Tab.Pane>
+                </Tab.Content>
+            );
+        }
+        else {
+            return (
+                <Tab.Content>
+                    <Tab.Pane eventKey={1} disabled="disabled">
+                        <ServiceConfigFlow1
+                            gotoStart={this.props.forward}
+                            voucher = {this.props.voucher}
+                            inChannelConfig={this.props.inChannelConfig}
+                        />
+                    </Tab.Pane>
+                </Tab.Content>
+            );
+        }
+    }
+}

--- a/src/client/components/ServiceConfigFlowPortal/ServiceConfigFlow1.js
+++ b/src/client/components/ServiceConfigFlowPortal/ServiceConfigFlow1.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import {Button} from 'react-bootstrap';
+import InChannelConfig from '../../api/InChannelConfig.js';
+
+
+export default class ServiceConfigFlow1 extends React.Component {
+
+	constructor(props) {
+		super(props);
+
+        this.state = {
+            intention : this.props.intention
+        };
+	}
+
+    static propTypes = {
+        inChannelConfig : React.PropTypes.object,
+        intention: React.PropTypes.bool
+    };
+
+    static defaultProps = {
+        intention: null
+    };
+
+	static contextTypes = {
+        i18n : React.PropTypes.object.isRequired,
+    };
+
+
+    componentWillMount() {
+        this.setState({
+            "intention": this.props.inChannelConfig && this.props.inChannelConfig.SupplierPortalConfig && this.props.inChannelConfig.SupplierPortalConfig.intention
+        });
+    }
+
+
+    approveIntention = ()=>{
+    	InChannelConfig.update(
+            this.props.voucher.supplierId,
+            {
+                inputType:'portal',
+                intention:true
+            })
+
+        // this.setState({"intention": true});
+    	this.props.gotoStart(true);
+    }
+
+    rejectIntention = ()=> {
+        InChannelConfig.update(
+            this.props.voucher.supplierId,
+            {
+                inputType:'portal',
+                intention:false
+            })
+        // this.setState({"intention": false});
+    	this.props.gotoStart(false);
+    }
+
+
+    renderCurrentIntentionState = () => {
+        if (this.props.inChannelConfig && this.props.inChannelConfig.SupplierPortalConfig) {
+            // let status = this.props.inChannelConfig.SupplierPortalConfig.intention ? "portalRequested" : "portalRejected";
+            let status = this.state.intention ? "portalRequested" : "portalRejected";
+            return (
+                <div>
+                    <h5>
+                        {this.context.i18n.getMessage('ServiceConfigFlow.Portal.currentStatus')}
+                        {this.context.i18n.getMessage('ServiceConfigFlowStart.statuses.' + status)}
+                    </h5>
+                </div>
+            );
+        }
+    }
+
+	render() {
+		return (
+			<div>
+				<h3>{this.context.i18n.getMessage('welcome')}</h3>
+
+				<div className="bs-callout bs-callout-info">
+                    <div>
+						{this.context.i18n.getMessage('ServiceConfigFlow.Portal.intro1')}
+                    </div>
+                    <div>
+						{this.context.i18n.getMessage('ServiceConfigFlow.Portal.intro2')}
+                    </div>
+                </div>
+
+                {this.renderCurrentIntentionState()}
+
+				<div className="form-submit text-right">
+					<Button bsStyle = "link" onClick={()=>this.rejectIntention()}>
+						{this.context.i18n.getMessage('ServiceConfigFlow.Portal.portalNotWanted')}
+					</Button>
+					<Button bsStyle = "primary" onClick={()=>this.approveIntention()}>
+						{this.context.i18n.getMessage('ServiceConfigFlow.Portal.portalWanted')}
+					</Button>
+				</div>
+			</div>
+		)
+	}
+}

--- a/src/client/components/ServiceConfigFlowStart.js
+++ b/src/client/components/ServiceConfigFlowStart.js
@@ -180,6 +180,15 @@ export default class ServiceConfigFlowStart extends React.Component
         }
     }
 
+    getPortalState = () => {
+        if (this.props.inChannelConfig && this.props.inChannelConfig.SupplierPortalConfig) {
+            return this.props.inChannelConfig.SupplierPortalConfig.intention ? "portalRequested" : "portalRejected";
+        }
+        else {
+            return "undefined";
+        }
+    }
+
     getPdfState = () => {
         let pdfConfig = this.props.inChannelConfig && this.props.inChannelConfig.PdfChannelConfig;
         let status = this.props.inChannelConfig && this.props.inChannelConfig.status;
@@ -271,16 +280,21 @@ export default class ServiceConfigFlowStart extends React.Component
                             <Radio
                                 disabled={!this.props.voucher.supplierPortalEnabled}
                                 onChange={ this.onInvoiceSendingTypeChanged }
-                                checked={ this.state.invoiceSendingType === 'supplier' }
-                                value="supplier"/>
+                                checked={ this.state.invoiceSendingType === 'portal' }
+                                value="portal"/>
                         </label>
                     </div>
                     <div className="col-md-11">
                         <div className={"panel panel-default " + (this.props.voucher.supplierPortalEnabled ? "" : "disabled")}>
                             <div className="panel-heading">
                                 <h4 className="panel-title">{this.context.i18n.getMessage('ServiceConfigFlowStart.supplierPortal')}
-                                    <BillingDetails inputType="supplierPortal" voucher={this.props.voucher} />
+                                    <BillingDetails inputType="portal" voucher={this.props.voucher} />
                                 </h4>
+                                {this.getPortalState() == 'undefined' ||
+                                    <div style={{ paddingTop: '10px'}}>
+                                        {(this.context.i18n.getMessage('ServiceConfigFlowStart.statuses.' + this.getPortalState()))}
+                                    </div>
+                                }
                             </div>
                             <div className="panel-body">
                                 {this.context.i18n.getMessage('ServiceConfigFlowStart.supplierPortalDesc')}

--- a/src/client/components/ServiceConfigFlowStart.js
+++ b/src/client/components/ServiceConfigFlowStart.js
@@ -288,7 +288,7 @@ export default class ServiceConfigFlowStart extends React.Component
                         <div className={"panel panel-default " + (this.props.voucher.supplierPortalEnabled ? "" : "disabled")}>
                             <div className="panel-heading">
                                 <h4 className="panel-title">{this.context.i18n.getMessage('ServiceConfigFlowStart.supplierPortal')}
-                                    <BillingDetails inputType="portal" voucher={this.props.voucher} />
+                                    <BillingDetails inputType="supplierPortal" voucher={this.props.voucher} />
                                 </h4>
                                 {this.getPortalState() == 'undefined' ||
                                     <div style={{ paddingTop: '10px'}}>

--- a/src/client/components/ServiceConfigFlowStart.js
+++ b/src/client/components/ServiceConfigFlowStart.js
@@ -111,7 +111,7 @@ export default class ServiceConfigFlowStart extends React.Component
             })
         })
         .then(() => {
-            this.props.openFlow(this.state.invoiceSendingType);
+            return this.props.openFlow(this.state.invoiceSendingType);
         })
         .catch((e) => {
             console.log("Error: ", e);

--- a/src/client/components/common/BillingDetails.js
+++ b/src/client/components/common/BillingDetails.js
@@ -20,6 +20,11 @@ export default class BillingDetails extends React.Component {
         if(this.props.inputType === "eInvoice" && this.props.voucher[this.props.inputType + "Enabled"]) {
             return null; // We don't know anything about the billing for external eInvoicing.
         }
+        else if(this.props.inputType === "supplierPortal" && this.props.voucher[this.props.inputType + "Enabled"]) {
+            return (
+              <span style={styleFree}>{this.context.i18n.getMessage('ServiceConfigFlowStart.intention')}</span>
+            ) // May be the same as eInvoice?!
+        }
         else if (this.props.inputType && this.props.voucher[this.props.inputType + "Enabled"]) {
             return (
                 <span style={styleFree}>{this.context.i18n.getMessage('ServiceConfigFlowStart.freeFor', {customerName : this.props.voucher.customerName})}</span>

--- a/src/client/components/common/BillingDetails.js
+++ b/src/client/components/common/BillingDetails.js
@@ -22,6 +22,11 @@ export default class BillingDetails extends React.Component {
                 <span style={styleFree}>{this.context.i18n.getMessage('ServiceConfigFlowStart.intention')}</span>
                 )
         }
+        else if(this.props.inputType === "supplierPortal" && this.props.voucher[this.props.inputType + "Enabled"]) {
+            return (
+                <span style={styleFree}>{this.context.i18n.getMessage('ServiceConfigFlowStart.intention')}</span>
+                )
+        }
         else if (this.props.inputType && this.props.voucher[this.props.inputType + "Enabled"]) {
             return (
                 <span style={styleFree}>{this.context.i18n.getMessage('ServiceConfigFlowStart.freeFor', {customerName : this.props.voucher.customerName})}</span>

--- a/src/client/i18n/de.js
+++ b/src/client/i18n/de.js
@@ -43,6 +43,9 @@ export default {
             activated: "Ist aktiviert.",
             notActivated: "Ist nicht aktiviert.",
 
+            portalRequested: "D! Sie wünschen eine Supplier Portal-Anbindung.",
+            portalRejected: "D! Sie wünschen keine Supplier Portal-Anbindung.",
+
             einvoiceRequested: "Sie wünschen eine eInvoice-Anbindung.",
             einvoiceRejected: "Sie wünschen keine eInvoice-Anbindung.",
             stated: "Ihre Wunsch ist hinterlegt."
@@ -60,6 +63,13 @@ export default {
             intro2: " Sobald eine Anbindung möglich ist, werden wir uns mit Ihnen in Verbindung setzen, sofern Sie dies wünschen und unten bestätigen.",
             einvoiceWanted: "Ja, wir wünschen eine eInvoice-Anbindung",
             einvoiceNotWanted: "Wir unterstützen kein eInvoice",
+            currentStatus: "Ihr aktueller Status: "
+        },
+        Portal:{
+            intro1: "D! Hier werden wir Ihnen die Konfiguration der Supplier Portal-Anbindung per Webservice anbieten. Leider ist diese noch nicht verfügbar.",
+            intro2: "Sobald eine Anbindung möglich ist, werden wir uns mit Ihnen in Verbindung setzen, sofern Sie dies wünschen und unten bestätigen.",
+            einvoiceWanted: "D! Ja, wir wünschen eine Supplier Portal-Anbindung",
+            einvoiceNotWanted: "D! Wir unterstützen kein Supplier Portal",
             currentStatus: "Ihr aktueller Status: "
         },
         Pdf:{

--- a/src/client/i18n/en.js
+++ b/src/client/i18n/en.js
@@ -43,6 +43,9 @@ export default {
             activated: "Is activated.",
             notActivated: "Is not activated.",
 
+            portalRequested: "You want to have an Supplier Portal integration.",
+            portalRejected: "You don't want an Supplier Portal integration.",
+
             einvoiceRequested: "You want to have an eInvoice integration.",
             einvoiceRejected: "You don't want an eInvoice integration.",
             stated: "Your intention is stated."
@@ -60,6 +63,13 @@ export default {
             intro2: "If you want to provide invoices via web service, please confirm this intention below.",
             einvoiceWanted:"Yes, we want to use eInvoice",
             einvoiceNotWanted:"No, we do not support eInvoice",
+            currentStatus: "Your current state: "
+        },
+        Portal:{
+            intro1: "We are sorry that we cannot provide an Supplier Portal web integration right now, but it will be available soon.",
+            intro2: "!Change: If you want to provide invoices via web service, please confirm this intention below.",
+            portalWanted:"Yes, we want to use Supplier Portal",
+            portalNotWanted:"No, we do not support Supplier Portal",
             currentStatus: "Your current state: "
         },
         Pdf:{

--- a/src/server/api/inChannelConfig.js
+++ b/src/server/api/inChannelConfig.js
@@ -160,7 +160,7 @@ module.exports.updateInChannelConfig = function(supplierId, config, returnConfig
     // Remove fields we do not want to be set from outside.
     [ 'type', 'createdOn', 'changedOn', 'createdBy' ].forEach(key => delete basicConfig[key]);
     // Copy required values to the extendedConfig as it is a plain object.
-    [ 'changedBy', 'rejectionEmail', 'intention', 'status' ].forEach(key => extendedConfig[key] = basicConfig[key]);
+    [ 'changedBy', 'rejectionEmail', 'intention', 'status' ].forEach(key => {if(key in basicConfig){extendedConfig[key] = basicConfig[key]}});
 
     // Override supplierId making sure it's the same on both.
     basicConfig.supplierId = supplierId;

--- a/src/server/api/inChannelConfig.js
+++ b/src/server/api/inChannelConfig.js
@@ -131,6 +131,12 @@ module.exports.addInChannelConfig = function(config, returnConfig)
         delete basicConfig.status;
     }
 
+    // TODO: As long as Portal is only an intention, we are not allowed to store the inputType for "portal" #copy of einvoice#
+    if (basicConfig.inputType == 'portal') {
+        delete basicConfig.intputType;
+        delete basicConfig.status;
+    }
+
     // Remove fields we do not want to be set from outside.
     [ 'createdOn', 'changedOn', 'changedBy' ].forEach(key => delete basicConfig[key]);
     // Copy required values to the extendedConfig as it is a plain object.
@@ -171,6 +177,12 @@ module.exports.updateInChannelConfig = function(supplierId, config, returnConfig
 
             // TODO: As long as eInvoice is only an intention, we are not allowed to store the inputType for "einvoice"
             if (newInputType == 'einvoice') {
+                basicConfig.inputType = oldInputType;
+                basicConfig.status = existingbasicConfig.status;
+            }
+
+            // TODO: As long as Portal is only an intention, we are not allowed to store the inputType for "portal" #copy of einvoice#
+            if (newInputType == 'portal') {
                 basicConfig.inputType = oldInputType;
                 basicConfig.status = existingbasicConfig.status;
             }

--- a/src/server/api/inChannelConfig.js
+++ b/src/server/api/inChannelConfig.js
@@ -58,14 +58,18 @@ module.exports.getInChannelConfig = function(supplierId)
             return Promise.all([
                 this.db.models.PdfChannelConfig.findById(supplierId),
                 this.db.models.EInvoiceChannelConfig.findById(supplierId),
+                this.db.models.SupplierPortalConfig.findById(supplierId),
                 this.getModelFromInputType(basicConfig.inputType).findById(supplierId)  // TODO: kept the attic approach to keep the interface structure - to be cleansed!
             ])
-            .spread((pdfConfig, einvoiceConfig, extendedConfig) => {
+            .spread((pdfConfig, einvoiceConfig, supplierConfig, extendedConfig) => {
                 if (pdfConfig) {
                     basicConfig.dataValues.PdfChannelConfig = pdfConfig;
                 }
                 if (einvoiceConfig) {
                     basicConfig.dataValues.EInvoiceChannelConfig = einvoiceConfig;
+                }
+                if (supplierConfig){
+                  basicConfig.dataValues.SupplierPortalConfig = supplierConfig;
                 }
 
                 // TODO: kept the attic approach to keep the interface structure - to be cleansed!
@@ -160,7 +164,7 @@ module.exports.updateInChannelConfig = function(supplierId, config, returnConfig
     // Remove fields we do not want to be set from outside.
     [ 'type', 'createdOn', 'changedOn', 'createdBy' ].forEach(key => delete basicConfig[key]);
     // Copy required values to the extendedConfig as it is a plain object.
-    [ 'changedBy', 'rejectionEmail', 'intention', 'status' ].forEach(key => {if(key in basicConfig){extendedConfig[key] = basicConfig[key]}});
+    [ 'changedBy', 'rejectionEmail', 'intention', 'status' ].forEach(key => {if(basicConfig.hasOwnProperty(key)){extendedConfig[key] = basicConfig[key]}});
 
     // Override supplierId making sure it's the same on both.
     basicConfig.supplierId = supplierId;

--- a/src/server/db/migrations/2-eInvoiceChannelConfig.main.js
+++ b/src/server/db/migrations/2-eInvoiceChannelConfig.main.js
@@ -10,5 +10,5 @@
  	);
  }
  module.exports.down = (db,config)=> {
- 	return db.queryInterface.dropColumn('intention');
+ 	return db.queryInterface.dropColumn('EInvoiceChannelConfig', 'intention');
  }

--- a/src/server/db/migrations/6-portal-enabled.main.js
+++ b/src/server/db/migrations/6-portal-enabled.main.js
@@ -1,0 +1,14 @@
+'use strict'
+ const DataTypes = require('sequelize');
+ module.exports.up = (db,config)=> {
+ 	return db.queryInterface.addColumn(
+ 		'SupplierPortalConfig',
+ 		'intention', {
+ 			type:DataTypes.BOOLEAN,
+ 			allowNull:true
+ 		}
+ 	);
+ }
+ module.exports.down = (db,config)=> {
+ 	return db.queryInterface.dropColumn('SupplierPortalConfig', 'intention');
+ }

--- a/src/server/db/models/inChannelConfig.js
+++ b/src/server/db/models/inChannelConfig.js
@@ -218,6 +218,10 @@ module.exports.init = function(db, config)
             type : DataTypes.DATE(),
             allowNull : true
         },
+        intention : {
+            type:DataTypes.BOOLEAN,
+            allowNull:true
+        },
         status: {
             type:DataTypes.STRING(100),
             allowNull:false,
@@ -348,54 +352,54 @@ module.exports.init = function(db, config)
 
     PdfChannelConfig.belongsTo(
         InChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     PaperChannelConfig.belongsTo(
         InChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     EInvoiceChannelConfig.belongsTo(
         InChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     SupplierPortalConfig.belongsTo(
         InChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
 
     InChannelConfig.hasOne(
         PdfChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     InChannelConfig.hasOne(
         PaperChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     InChannelConfig.hasOne(
         EInvoiceChannelConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
     InChannelConfig.hasOne(
         SupplierPortalConfig, {
-            targetKey: "supplierId", 
+            targetKey: "supplierId",
             foreignKey: "supplierId"
         }
     );
-    
+
 
 
 


### PR DESCRIPTION
#62 

- Added schema adjustments + fix on `down` method for einvoice migration.
- Enabled Supplier Portal.
- Copied Einvoice UI flow with adjustments.
- Added SupplierPortalConfig support to BasicConfig(inChannelConfig) - StartFlow didn't see it -> was not showing status under h4.
- Added translations, but German lang should be adjusted: marked as D!
